### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12.4
+
+COPY . .
+
+RUN npm install -g yarn
+RUN yarn
+CMD ["yarn", "test"]


### PR DESCRIPTION
This should allow the execution of the jest unit tests using this command:
> docker build . -t cmsi && docker run cmsi

That way people can modify the source Javascript and run the above to run the unit tests without needing to install anything other than Docker.

This is what the output looks like: https://i.imgur.com/tvriPOj.png